### PR TITLE
Implemented Exception handling for Post and Comment. Not Null, and mi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.modelmapper</groupId>
 			<artifactId>modelmapper</artifactId>
 			<version>3.1.0</version>

--- a/src/main/java/com/springboot/blog/controller/CommentController.java
+++ b/src/main/java/com/springboot/blog/controller/CommentController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -17,7 +18,7 @@ public class CommentController {
     private CommentService commentService;
 
     @PostMapping("/{postId}/comments")
-    public ResponseEntity<CommentDTO> createComment(@PathVariable long postId,@RequestBody CommentDTO commentDTO) {
+    public ResponseEntity<CommentDTO> createComment(@PathVariable long postId,@Valid @RequestBody CommentDTO commentDTO) {
 
         return new ResponseEntity<>(commentService.createComment(postId, commentDTO), HttpStatus.CREATED);
     }
@@ -38,7 +39,7 @@ public class CommentController {
     }
 
     @PutMapping("/{postId}/comments/{commentId}")
-    public ResponseEntity<CommentDTO> updateCommentByPostId(@PathVariable(name = "postId") Long postId, @PathVariable(name = "commentId") Long commentId,@RequestBody CommentDTO commentDTO) {
+    public ResponseEntity<CommentDTO> updateCommentByPostId(@PathVariable(name = "postId") Long postId, @PathVariable(name = "commentId") Long commentId,@Valid @RequestBody CommentDTO commentDTO) {
 
         return new ResponseEntity<>(commentService.updateCommentByPostId(postId, commentId, commentDTO), HttpStatus.OK);
 

--- a/src/main/java/com/springboot/blog/controller/PostController.java
+++ b/src/main/java/com/springboot/blog/controller/PostController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -21,7 +22,7 @@ public class PostController {
 
     //create blog post
     @PostMapping("/post")
-    public ResponseEntity<PostDTO> createPost(@RequestBody PostDTO postDTO) {
+    public ResponseEntity<PostDTO> createPost(@Valid @RequestBody PostDTO postDTO) {
         return new ResponseEntity<>(postService.createPost(postDTO), HttpStatus.CREATED);
     }
 
@@ -53,7 +54,7 @@ public class PostController {
 
     //update post by postId
     @PutMapping("/post/{postId}")
-    public ResponseEntity<PostDTO> updatePost(@RequestBody PostDTO postDTO,@PathVariable long postId) {
+    public ResponseEntity<PostDTO> updatePost(@Valid @RequestBody PostDTO postDTO,@PathVariable long postId) {
 
         return new ResponseEntity<>(postService.updatePost(postDTO, postId), HttpStatus.OK);
     }

--- a/src/main/java/com/springboot/blog/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/springboot/blog/exception/GlobalExceptionHandler.java
@@ -1,16 +1,22 @@
 package com.springboot.blog.exception;
 
 import com.springboot.blog.payload_dto.ErrorDetails;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 @ControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
 //handle specific exceptions
 
@@ -42,6 +48,40 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorDetails, HttpStatus.INTERNAL_SERVER_ERROR);
 
     }
+
+    //handling the fields that should not be empty or have a min of characters
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException exception, HttpHeaders httpHeaders
+    , HttpStatus httpStatus
+    , WebRequest webRequest) {
+
+        Map<String, String> errors = new HashMap<>();
+        exception.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError)error).getField();
+            String message = error.getDefaultMessage();
+            errors.put(fieldName, message);
+        });
+
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+
+/*
+    This method is the same as the method above it just handled differently from the method
+    handleMethodArgumentNotValid that you're overriding. (But need the extends of ResponseEntityExceptionHandler
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handlesMethodArgumentNotValidException(MethodArgumentNotValidException exception, WebRequest webRequest) {
+
+        Map<String, String> errors = new HashMap<>();
+        exception.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError)error).getField();
+            String message = error.getDefaultMessage();
+            errors.put(fieldName, message);
+        });
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+
+    }
+*/
 
 
 

--- a/src/main/java/com/springboot/blog/payload_dto/CommentDTO.java
+++ b/src/main/java/com/springboot/blog/payload_dto/CommentDTO.java
@@ -2,13 +2,25 @@ package com.springboot.blog.payload_dto;
 
 import lombok.Data;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+
 @Data
 public class CommentDTO {
 
 
     private long commmentId;
+
+    @NotEmpty(message = "Name can't be null or empty.")
     private String name;
+
+    @NotEmpty(message = "Email can't be null or empty.")
+    @Email(message = "Email format should be like this example: email@text.com")
     private String email;
+
+    @NotEmpty
+    @Size(min = 10, message = "This should have at least 10 characters.")
     private String body;
 
 }

--- a/src/main/java/com/springboot/blog/payload_dto/PostDTO.java
+++ b/src/main/java/com/springboot/blog/payload_dto/PostDTO.java
@@ -2,14 +2,25 @@ package com.springboot.blog.payload_dto;
 
 import lombok.Data;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
 import java.util.Set;
 
 @Data
 public class PostDTO {
 
     private long postId;
+
+    @NotEmpty
+    @Size(min = 2, message = "Post title must have at least 2 characters.")
     private String title;
+
+    @NotEmpty
+    @Size(min = 10, message = "Post description must have at least 10 characters.")
     private String description;
+
+    @NotEmpty
+    @Size(min = 2, message = "Post description must have at least 2 characters.")
     private String content;
     //has to be the same name as PostEntity
     private Set<CommentDTO> comments;


### PR DESCRIPTION
Added custom exception handling for both Post and Comment. Certain fields can not be null or require a certain size when trying to create or update. If these requirements are not met a message will appear as an error instead of the long standard exception log.